### PR TITLE
fix pip3 installs for Python3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ais2adsb.py /usr/local/bin/
 
 RUN set -x && \
 apt-get update -y && apt-get install -q -o Dpkg::Options::="--force-confnew" -y --no-install-recommends --no-install-suggests git python3-bitarray && \
-pip install pyais && \
+pip3 install --break-system-packages --no-cache-dir pyais && \
 #
 # Add Container Version
 pushd /tmp && \


### PR DESCRIPTION
Python 3.11 works with virtual environments as a default. Since we are installing Python into a container, we need to now specifically allow pip3 to install at the system level rather than into a virtual environment